### PR TITLE
fix: stop using loadRelationIds, optimize calls

### DIFF
--- a/packages/bcer-api/app/src/business/business.service.ts
+++ b/packages/bcer-api/app/src/business/business.service.ts
@@ -21,8 +21,12 @@ export class BusinessService {
     return await this.businessRepository.save(business);
   }
 
-  async getBusinesses() {
-    const businesses = await this.businessRepository.find({ relations: ['users', 'locations', 'submissions'] });
+  async getBusinesses(payload?: { relations?: string[] }) {
+    let relations = ['users', 'locations', 'submissions'];
+    if (payload?.relations?.length) {
+      relations = payload.relations;
+    }
+    const businesses = await this.businessRepository.find({ relations });
     return businesses;
   }
 

--- a/packages/bcer-api/app/src/sales/entities/sales.entity.ts
+++ b/packages/bcer-api/app/src/sales/entities/sales.entity.ts
@@ -21,9 +21,15 @@ export class SalesReportEntity {
   @JoinColumn()
   product: ProductEntity;
 
+  @Column('varchar')
+  productId?: string;
+
   @ManyToOne(() => LocationEntity, (location: LocationEntity) => location.sales)
   @JoinColumn()
   location: ProductEntity;
+
+  @Column('varchar')
+  locationId?: string;
 
   @Column('varchar')
   containers: string;

--- a/packages/bcer-api/app/src/sales/sales.service.ts
+++ b/packages/bcer-api/app/src/sales/sales.service.ts
@@ -34,6 +34,26 @@ export class SalesReportService {
     });
     return sales;
   }
+
+  async getLocationsWithSalesReports(locationIds: string[]): Promise<Record<string, SalesReportEntity[]>> {
+    if (locationIds.length === 0) return {};
+    const sales = await this.salesReportRepository.find({
+      where: {
+        locationId: In(locationIds),
+      }
+    });
+
+    const locationWithSales = sales.reduce((dict, sale) => {
+      if (!!dict[sale.locationId]) {
+        dict[sale.locationId].push(sale);
+      } else {
+        dict[sale.locationId] = [sale];
+      }
+      return dict;
+    }, {});
+
+    return locationWithSales;
+  }
   
   async getSalesReports() {
     const sales = await this.salesReportRepository.find();


### PR DESCRIPTION
A few big changes here essentially to get rid of `loadAllRelationIds()` which is a very inefficient TypeOrm call when a many-to-many relation is in the 15000s. We instead get every single table and map them to each location manually.