### PR TITLE
Bugfix/vape 332 product submission optimization

### DIFF
--- a/packages/bcer-api/app/src/location/entities/location.entity.ts
+++ b/packages/bcer-api/app/src/location/entities/location.entity.ts
@@ -92,6 +92,10 @@ export class LocationEntity {
   @JoinTable()
   manufactures: ManufacturingEntity[];
 
+  productsCount?: number;
+  manufacturesCount?: number;
+  salesCount?: number;
+
   toResponseObject(): LocationRO {
     return {
       id: this.id,
@@ -112,6 +116,9 @@ export class LocationEntity {
       products: this.products?.map((product: ProductEntity) => product.toResponseObject()),
       sales: this.sales?.map((sale: SalesReportEntity) => sale.toResponseObject()),
       manufactures: this.manufactures?.map((manufacturing: ManufacturingEntity) => manufacturing.toResponseObject()),
+      productsCount: this.productsCount,
+      manufacturesCount: this.manufacturesCount,
+      salesCount: this.salesCount,
       created_at: this.created_at,
       updated_at: this.updated_at,
     };

--- a/packages/bcer-api/app/src/location/location.controller.ts
+++ b/packages/bcer-api/app/src/location/location.controller.ts
@@ -23,6 +23,7 @@ import {
   ApiOperation,
   ApiResponse,
   ApiBearerAuth,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { AuthGuard } from 'src/auth/guards/auth.guard';
 import { BusinessGuard } from 'src/user/guards/business.guard';
@@ -50,9 +51,15 @@ export class LocationController {
 
   @ApiOperation({ summary: 'Get Locations' })
   @ApiResponse({ status: HttpStatus.OK, type: [LocationRO] })
-  @ApiParam({
+  @ApiQuery({
     name: 'includes',
-    description: 'Comma separated list of relations to includes. For all: business,nois,products,manufactures'
+    description: 'Comma separated list of relations to includes. For all: business,nois,products,manufactures',
+    required: false,
+  })
+  @ApiQuery({
+    name: 'count',
+    description: 'Comma separated list of relations to find if relations exist. For all: products,manufactures,sales',
+    required: false,
   })
   @HttpCode(HttpStatus.OK)
   @Roles('user')
@@ -61,8 +68,9 @@ export class LocationController {
   async getLocation(
     @Request() req: RequestWithUser,
     @Query('includes') includes: string,
+    @Query('count') count: string,
   ): Promise<LocationRO[]> {
-    const locations = await this.service.getBusinessLocations(req.ctx.businessId, includes)
+    const locations = await this.service.getBusinessLocations(req.ctx.businessId, includes, count)
     return locations.map(location => location.toResponseObject())
   }
 

--- a/packages/bcer-api/app/src/location/location.service.ts
+++ b/packages/bcer-api/app/src/location/location.service.ts
@@ -1,4 +1,4 @@
-import { Repository, In, Not, IsNull } from 'typeorm';
+import { Repository, In, Not, IsNull, SelectQueryBuilder } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ForbiddenException, Injectable, Logger } from '@nestjs/common';
 import JSZip from 'jszip';
@@ -86,12 +86,27 @@ export class LocationService {
     return location;
   }
 
-  async getBusinessLocations(businessId: string, includes?: string) {
-    const locations = await this.locationRepository.find({
-      where: {
-        business: { id: businessId }
-      }, relations: includes ? includes.split(',') : []
-    });
+  async getBusinessLocations(businessId: string, includes?: string, count?: string) {
+    const locationsQb = this.locationRepository.createQueryBuilder('location');
+    locationsQb.andWhere('location.businessId = :businessId', { businessId });
+    if (includes && includes.length > 0) {
+      includes.split(',').forEach((include) => {
+        if (!['business', 'noi', 'products', 'manufactures', 'sales'].includes(include)) {
+          throw new ForbiddenException('Invalid includes');
+        }
+        locationsQb.leftJoinAndSelect(`location.${include}`, include);
+      });
+    }
+    if (count && count.length > 0) {
+      count.split(',').forEach((colToCount) => {
+        if (!['products', 'manufactures', 'sales'].includes(colToCount)) {
+          throw new ForbiddenException('Invalid count');
+        }
+        locationsQb.addSelect((subQuery) => this.buildCountSubquery(colToCount, subQuery), `${colToCount}Count`);
+        locationsQb.loadRelationCountAndMap('location.productsCount', 'location.products');
+      });
+    }
+    const locations = await locationsQb.getMany();
     return locations;
   }
 
@@ -217,5 +232,25 @@ export class LocationService {
         Logger.log('zip written.');
       }
     );
+  }
+
+  private buildCountSubquery = (relation: string, qb: SelectQueryBuilder<any>) => {
+    if (relation === 'products') {
+      return qb
+        .select('COUNT(p.productId)')
+        .from('location_products_product', 'p')
+        .where('p.locationId = location.id');
+    } else if (relation === 'manufactures') {
+      return qb
+        .select('COUNT(m.manufacturingId)')
+        .from('location_manufactures_manufacturing', 'm')
+        .where('m.locationId = location.id');
+    } else if (relation === 'sales') {
+      return qb
+        .select('COUNT(s.id)')
+        .from('salesreport', 's')
+        .where('s.locationId = location.id');
+    }
+    throw new ForbiddenException('Forbidden relation');
   }
 }

--- a/packages/bcer-api/app/src/location/ro/location.ro.ts
+++ b/packages/bcer-api/app/src/location/ro/location.ro.ts
@@ -57,10 +57,19 @@ export class LocationRO {
   manufactures?: ManufacturingRO[];
 
   @ApiProperty()
+  manufacturesCount?: number = 0;
+
+  @ApiProperty()
   products?: ProductRO[];
 
   @ApiProperty()
+  productsCount?: number = 0;
+
+  @ApiProperty()
   sales?: SalesReportRO[];
+
+  @ApiProperty()
+  salesCount?: number = 0;
 
   @ApiProperty()
   created_at: Date;

--- a/packages/bcer-api/app/src/products/products.controller.ts
+++ b/packages/bcer-api/app/src/products/products.controller.ts
@@ -47,9 +47,9 @@ export class ProductsController {
   async createProducts(
     @Body() payload: ProductsDTO,
     @Request() req: RequestWithUser,
-    ): Promise<ProductRO[]> {
+    ): Promise<void> {
     const products = await this.service.createProducts(payload, req.ctx.businessId);
-    return products.map(p => p.toResponseObject());
+    return;
   }
 
   @ApiOperation({ summary: 'Get Products' })

--- a/packages/bcer-api/app/src/user/user.controller.ts
+++ b/packages/bcer-api/app/src/user/user.controller.ts
@@ -73,13 +73,13 @@ export class UserController {
       }
     }
     const business = await this.businessService.getBusinessById(businessId);
-    const locations = await this.locationService.getBusinessLocations(businessId, 'noi,products,manufactures');
+    const locations = await this.locationService.getBusinessLocations(businessId, 'noi', 'products,manufactures');
 
     let statusObject = {
       myBusinessComplete: Boolean(business.legalName && business.email),
       noiComplete: locations.length > 0 ? locations.every(l => l.noi) : false,
-      productReportComplete: locations.length > 0 ? locations.every(l => l.products.length) : false,
-      manufacturingReportComplete: locations.length > 0 ? locations.filter(l => l.manufacturing).every(l => l.manufactures.length) : false,
+      productReportComplete: locations.length > 0 ? locations.every(l => l.products?.length || l.productsCount > 0) : false,
+      manufacturingReportComplete: locations.length > 0 ? locations.every(l => l.manufactures?.length || l.manufacturesCount > 0) : false,
     };
 
     return statusObject;

--- a/packages/bcer-retailer-app/app/src/constants/localInterfaces.tsx
+++ b/packages/bcer-retailer-app/app/src/constants/localInterfaces.tsx
@@ -56,8 +56,11 @@ export interface BusinessLocation {
   noi?: {
     created_at: Date
   },
-  products?: Array<Products>
-  sales?: Array<Sale>
+  products?: Array<Products>;
+  productsCount: number;
+  manufacturesCount: number;
+  sales?: Array<Sale>;
+  salesCount: number;
   created_at?: Date;
 }
 

--- a/packages/bcer-retailer-app/app/src/views/Sales/Overview.tsx
+++ b/packages/bcer-retailer-app/app/src/views/Sales/Overview.tsx
@@ -74,7 +74,7 @@ export default function SalesOverview() {
   const [submitted, setSubmitted] = useState([]);
 
   const { location: { pathname } } = history;
-  const [{ data: locations = [], loading, error }] = useAxiosGet(`/location?includes=sales,products`);
+  const [{ data: locations = [], loading, error }] = useAxiosGet(`/location?count=sales,products`);
   const [appGlobal, setAppGlobal] = useContext(AppGlobalContext);
 
   const tableAction = () => (
@@ -89,8 +89,8 @@ export default function SalesOverview() {
 
   useEffect(() => {
     if (locations.length && !error) {
-      const outstanding = locations.filter((l: BusinessLocation) => !l.sales || l.sales.length === 0);
-      const submitted = locations.filter((l: BusinessLocation) => l?.sales.length > 0);
+      const outstanding = locations.filter((l: BusinessLocation) => (!l.sales || l.sales?.length === 0) || l.salesCount === 0);
+      const submitted = locations.filter((l: BusinessLocation) => l?.sales?.length > 0 || l.salesCount > 0);
       setOutstanding(outstanding);
       setSubmitted(submitted);
     } else {

--- a/packages/bcer-retailer-app/app/src/views/productReport/AddProductReports.tsx
+++ b/packages/bcer-retailer-app/app/src/views/productReport/AddProductReports.tsx
@@ -200,7 +200,7 @@ export default function AddProductReports() {
   }
   const selectFromLocation = async() => { 
     if (value) {
-      await get({ url:`/location/${value.id}?count=products` })
+      await get({ url:`/location/${value.id}?includes=products` })
       history.push('/products/confirm-products')
     }
   }

--- a/packages/bcer-retailer-app/app/src/views/productReport/AddProductReports.tsx
+++ b/packages/bcer-retailer-app/app/src/views/productReport/AddProductReports.tsx
@@ -118,7 +118,7 @@ export default function AddProductReports() {
   const [productInfo, setProductInfo] = useContext(ProductInfoContext);
   const [appGlobal, setAppGlobal] = useContext(AppGlobalContext);
   const [{ loading: productsLoading, error: productsError, data: productsData }, get] = useAxiosGet('/location/:id/products', { manual: true });
-  const [{ loading: locationsLoading, error: locationsError, data: locations }, getLocations] = useAxiosGet('/location?includes=products');
+  const [{ loading: locationsLoading, error: locationsError, data: locations }, getLocations] = useAxiosGet('/location?count=products');
   const [{ loading: postLoading, error: postError, data: newSubmission }, patch] = useAxiosPatch('/submission', { manual: true });
   const [{ error: mapError, response: mapResponse, data: mappedSubmission }, patchMap] = useAxiosPatch('/submission/map', { manual: true });
 
@@ -200,7 +200,7 @@ export default function AddProductReports() {
   }
   const selectFromLocation = async() => { 
     if (value) {
-      await get({ url:`/location/${value.id}?includes=products` })
+      await get({ url:`/location/${value.id}?count=products` })
       history.push('/products/confirm-products')
     }
   }
@@ -324,7 +324,7 @@ export default function AddProductReports() {
                             onChange={(event: React.ChangeEvent<any>, newValue: BusinessLocation) => setValue(newValue)}
                             inputValue={inputValue}
                             onInputChange={(event: React.ChangeEvent<any>, newInputValue: string | null) => setInputValue(newInputValue)}
-                            options={locations.filter((l: any) => l.products.length)}
+                            options={locations.filter((l: any) => l.products?.length || l.productsCount > 0)}
                             getOptionLabel={(option: BusinessLocation) => option.addressLine1}
                           />
                         </div>

--- a/packages/bcer-retailer-app/app/src/views/productReport/Overview.tsx
+++ b/packages/bcer-retailer-app/app/src/views/productReport/Overview.tsx
@@ -118,7 +118,7 @@ export default function ProductOverview() {
   const { location: { pathname } } = history;
   const [withProducts, setWithProducts] = useState([]);
   const [withoutProducts, setWithoutProducts] = useState([]);
-  const [{ data: locations = [], loading, error }] = useAxiosGet(`/location?includes=products`);
+  const [{ data: locations = [], loading, error }] = useAxiosGet(`/location?count=products`);
   const [{ loading: patchLoading, error: patchError, data: patchedSubmission }, patch] = useAxiosPatch('/submission', { manual: true });
   const [productInfo, setProductInfo] = useContext(ProductInfoContext);
   const [appGlobal, setAppGlobal] = useContext(AppGlobalContext);
@@ -147,8 +147,8 @@ export default function ProductOverview() {
 
   useEffect(() => {
     if (locations.length && !error) {
-      const withProducts = locations?.filter((l: BusinessLocation) => l.products.length) || [];
-      const withoutProducts = locations?.filter((l: BusinessLocation) => !l.products.length) || [];
+      const withProducts = locations?.filter((l: BusinessLocation) => l.products?.length || l.productsCount > 0) || [];
+      const withoutProducts = locations?.filter((l: BusinessLocation) => !l.products?.length || l.productsCount === 0) || [];
       setWithProducts(withProducts);
       setWithoutProducts(withoutProducts);
     } else {
@@ -167,7 +167,7 @@ export default function ProductOverview() {
       }
     }
     if (pathname.includes('success')) {
-      if (locations.length > 0 && !locations.find((l: BusinessLocation) => l.products?.length === 0)) {
+      if (locations.length > 0 && !locations.find((l: BusinessLocation) => l.products?.length === 0 || l.productsCount === 0)) {
         setAppGlobal({ ...appGlobal, productReportComplete: true });
       };
     };
@@ -197,7 +197,7 @@ export default function ProductOverview() {
                 <Typography variant='body1'>
                   You need to submit product reports for all locations listed in the "Outstanding Product Reports"
                   section of this page. Click the "Submit Product Report" button to begin your submission.
-                    </Typography>
+                </Typography>
               </div>
             </div>
             :
@@ -320,7 +320,7 @@ export default function ProductOverview() {
                 },
                 {
                   title: 'Status',
-                  render: (rd: BusinessLocation) => `${rd.products.length ? 'Submitted' : 'Not Submitted'}`
+                  render: (rd: BusinessLocation) => `${rd.products?.length || rd.productsCount > 0 ? 'Submitted' : 'Not Submitted'}`
                 },
               ]}
               actions={[

--- a/packages/bcer-retailer-app/app/src/views/productReport/SelectLocations.tsx
+++ b/packages/bcer-retailer-app/app/src/views/productReport/SelectLocations.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useContext, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useAxiosGet, useAxiosPatch } from '@/hooks/axios';
-import { makeStyles, Typography, Paper } from '@material-ui/core';
+import { makeStyles, Typography, Paper, Snackbar } from '@material-ui/core';
 import { CSVLink } from 'react-csv';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import ChatBubbleOutlineIcon from '@material-ui/icons/ChatBubbleOutline';
@@ -68,7 +68,7 @@ export default function SelectLocations() {
   const classes = useStyles();
   const history = useHistory();
 
-  const [{ data: locations = [], loading, error }, get] = useAxiosGet(`/location?includes=products`); 
+  const [{ data: locations = [], loading, error }, get] = useAxiosGet(`/location`); 
   const [{ response, loading: patchLoading, error: patchError }, patch] = useAxiosPatch(`/products`, { manual: true });
   const [isConfirmOpen, setOpenConfirm] = useState<boolean>(false);
   const [selectedProducts, setSelectedProducts] = useState([]);
@@ -120,7 +120,13 @@ export default function SelectLocations() {
         <Paper className={classes.box} variant='outlined'>
           <Typography className={classes.boxTitle} variant='subtitle1'>Select locations that this report applies to.</Typography>
           <div className={classes.actionsWrapper}>
-            <Typography className={classes.tableRowCount} variant='body2'>You have {locations.length} retail locations</Typography>
+            <Typography className={classes.tableRowCount} variant='body2'>
+              You have {locations.length} retail locations.
+              {productInfo.products.length * productInfo.locations.length < 200000
+                ? ` You are submitting ${productInfo.products.length} products to ${productInfo.locations.length} locations.`
+                : ` Please limit your submission to ${Math.floor(200000 / productInfo.products.length)} locations.`
+              }
+            </Typography>
             {
               locations.length
               ?
@@ -161,12 +167,17 @@ export default function SelectLocations() {
           <StyledButton
             variant='contained'
             onClick={() => setOpenConfirm(true)}
-            disabled={!selectedProducts.length}
+            disabled={!selectedProducts.length || productInfo.products.length * productInfo.locations.length > 200000}
           >
             Submit
           </StyledButton>
         </div>
       </div>
+      <Snackbar
+        open={patchLoading}
+        message={'Submitting product report. Please wait...'}
+        ClickAwayListenerProps={{mouseEvent: false, touchEvent: false}}
+      />
       <StyledConfirmDialog
         open={isConfirmOpen}
         maxWidth='sm'

--- a/packages/bcer-retailer-app/app/src/views/productReport/SelectLocations.tsx
+++ b/packages/bcer-retailer-app/app/src/views/productReport/SelectLocations.tsx
@@ -186,6 +186,8 @@ export default function SelectLocations() {
         dialogMessage='You are about to submit your product report.'
         setOpen={() => setOpenConfirm(false)}
         confirmHandler={confirmSubmit}
+        acceptDisabled={patchLoading}
+        cancelDisabled={patchLoading}
       />
     </>
   );

--- a/packages/bcer-shared-components/src/components/dialogs/StyledDialog.tsx
+++ b/packages/bcer-shared-components/src/components/dialogs/StyledDialog.tsx
@@ -58,6 +58,8 @@ export function StyledDialog ({
   acceptButtonText,
   cancelHandler,
   acceptHandler,
+  acceptDisabled,
+  cancelDisabled,
   ...props
 }: StyledDialogProps):ReactElement {
   
@@ -79,6 +81,8 @@ export function StyledDialog ({
         cancelHandler={cancelHandler}
         acceptButtonText={acceptButtonText} 
         acceptHandler={acceptHandler}
+        acceptDisabled={acceptDisabled || false}
+        cancelDisabled={cancelDisabled || false}
       />
     </Dialog>
   );

--- a/packages/bcer-shared-components/src/constants/interfaces/dialogInterfaces.ts
+++ b/packages/bcer-shared-components/src/constants/interfaces/dialogInterfaces.ts
@@ -7,6 +7,8 @@ export interface StyledDialogProps extends DialogProps {
   acceptButtonText: string,
   cancelHandler: ReactEventHandler,
   acceptHandler: ReactEventHandler | "submit",
+  acceptDisabled?: boolean,
+  cancelDisabled?: boolean,
 }
 
 export interface StyledConfirmDialogProps extends DialogProps {
@@ -15,6 +17,8 @@ export interface StyledConfirmDialogProps extends DialogProps {
   dialogMessage: string,
   checkboxLabel: string,
   dialogTitle: string,
+  acceptDisabled?: boolean,
+  cancelDisabled?: boolean,
 }
 
 export interface StyledDialogActionProps {


### PR DESCRIPTION
This PR addresses some of the bugs around product submission and product retrieval by optimizing our queries. It's typically a working flow until a retailer submits 15000+ products, and then we run into issues for one reason or another, usually due to TypeORM mapping taking time. As well, because products <-> locations are a many-to-many relation, there's a ton being loaded for a retailer with 10 locations and 15000 products each.

For submission, this is addressed by using raw queries to the db rather than the TypeORM repository for creating relations.
For retrieval, this is addressed by subqueries, and using a count instead of an includes for products. We hardly ever need to get a location's products unless it's a single location, so by just getting the count, we can speed up the query by a lot.