### PR TITLE
Feature/VAPE-406 Added build command to build + package api, data portal, and retailer app

### DIFF
--- a/.build/package-app.sh
+++ b/.build/package-app.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+########################################################################################
+# Utility script to build and package
+# - API
+# - Data Portal
+# - Retailer App
+# This command outputs each of the built apps as a tar.gz file in the dist/ folder. 
+#
+# Usage:
+# - VERSION=<app_version> ENVIRONMENT=<development|staging|production> ./package-app.sh
+########################################################################################
+
+ROOT_DIR=$(pwd)
+DIST_FOLDER=$ROOT_DIR/dist
+
+echo "VERSION=${VERSION}"
+echo "ENVIRONMENT=${ENVIRONMENT}"
+
+if [ -z "${VERSION}" ]; then
+    echo "No VERSION specified"
+    exit 0;
+fi
+
+if [ -z "${ENVIRONMENT}" ]; then
+    echo "No ENVIRONMENT specified"
+    exit 0;
+fi
+
+BUILD_SUFFIX=${ENVIRONMENT}-${VERSION}
+
+function packageApi() {
+    cd $ROOT_DIR/packages/bcer-api
+    ENVIRONMENT=${ENVIRONMENT} make package-app
+
+    mv ./dist.tar.gz $DIST_FOLDER/${BUILD_SUFFIX}/api-${BUILD_SUFFIX}.tar.gz
+}
+
+function buildSharedComponents() {
+    cd $ROOT_DIR/packages/bcer-shared-components
+    ENVIRONMENT=${ENVIRONMENT} make build
+}
+
+function packageRetailerApp() {
+    cd $ROOT_DIR/packages/bcer-retailer-app
+    ENVIRONMENT=${ENVIRONMENT} make package-app
+    mv ./build.tar.gz $DIST_FOLDER/${BUILD_SUFFIX}/retailer-${BUILD_SUFFIX}.tar.gz
+}
+
+function packageDataPortal() {
+    cd $ROOT_DIR/packages/bcer-data-portal
+    ENVIRONMENT=${ENVIRONMENT} make package-app
+    mv ./build.tar.gz $DIST_FOLDER/${BUILD_SUFFIX}/data-portal-${BUILD_SUFFIX}.tar.gz
+}
+
+# Create new dist folder if not already exists
+mkdir -p $DIST_FOLDER/$BUILD_SUFFIX
+
+packageApi
+buildSharedComponents
+packageRetailerApp
+packageDataPortal

--- a/.build/package-app.sh
+++ b/.build/package-app.sh
@@ -33,7 +33,7 @@ function packageApi() {
     cd $ROOT_DIR/packages/bcer-api
     ENVIRONMENT=${ENVIRONMENT} make package-app
 
-    mv ./dist.tar.gz $DIST_FOLDER/${BUILD_SUFFIX}/api-${BUILD_SUFFIX}.tar.gz
+    mv ./dist.tar.gz $DIST_FOLDER/${BUILD_SUFFIX}/dist-${VERSION}.tar.gz
 }
 
 function buildSharedComponents() {
@@ -44,13 +44,13 @@ function buildSharedComponents() {
 function packageRetailerApp() {
     cd $ROOT_DIR/packages/bcer-retailer-app
     ENVIRONMENT=${ENVIRONMENT} make package-app
-    mv ./build.tar.gz $DIST_FOLDER/${BUILD_SUFFIX}/retailer-${BUILD_SUFFIX}.tar.gz
+    mv ./build.tar.gz $DIST_FOLDER/${BUILD_SUFFIX}/build-${BUILD_SUFFIX}.tar.gz
 }
 
 function packageDataPortal() {
     cd $ROOT_DIR/packages/bcer-data-portal
     ENVIRONMENT=${ENVIRONMENT} make package-app
-    mv ./build.tar.gz $DIST_FOLDER/${BUILD_SUFFIX}/data-portal-${BUILD_SUFFIX}.tar.gz
+    mv ./build.tar.gz $DIST_FOLDER/${BUILD_SUFFIX}/build-portal-${BUILD_SUFFIX}.tar.gz
 }
 
 # Create new dist folder if not already exists

--- a/Makefile
+++ b/Makefile
@@ -81,3 +81,8 @@ local-server-exec:
 build-local:
 	@echo "+\n++ Make: rebuilding and runing docker-compose"
 	@docker-compose -f docker-compose.dev.yml up --build
+
+build-deployment:
+	@echo "+\n++ Building + Packaging app for deployment"
+
+	.build/package-app.sh

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ build-local:
 	@echo "+\n++ Make: rebuilding and runing docker-compose"
 	@docker-compose -f docker-compose.dev.yml up --build
 
-build-deployment:
+package-build:
 	@echo "+\n++ Building + Packaging app for deployment"
 
 	.build/package-app.sh

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ The data portal application uses IDIR Keycloak for authentication.
 ## Shared Components
 The shared components are used for importing onto both the retailer application and the common portal. This package is developed and imported locally in the other frontend packages. However, after making changes to any shared components, `npm run build` must be ran within the shared components package for the other packages to find the changes.
 
+## Releases
+In order to create a new build of the application, you can use the `package-app` make command. This will build and package the
+- API (`dist-<version>.tar.gz`)
+- Retailer app (`build-<env>-<version>.tar.gz`)
+- Data Portal (`build-portal-<env>-<version>.tar.gz`)
+
+and output them as tar.gz files in the `dist` folder.
+
+Usage:
+```sh
+VERSION=<app_version> ENVIRONMENT=<development|staging|production> make package-app
+
+# Example 
+VERSION=2.2.0 ENVIRONMENT=development make package-app
+```
+
 ### Notes
 - At the moment, the containerized versions of these apps are non-functional.
 - Currently, we only deploy to on-prem servers. The documentation in each readme will reflect as such.

--- a/packages/bcer-api/.build/package-app.sh
+++ b/packages/bcer-api/.build/package-app.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+echo "+\n++ Building API"
+
+cd app
+npm i
+npm run build:prem
+
+echo "+\n++ Packaging API"
+npm run tar
+
+echo "+\n++ Finished building and packaging API"

--- a/packages/bcer-api/Makefile
+++ b/packages/bcer-api/Makefile
@@ -75,6 +75,9 @@ create-ecr-repos:
 	@aws ecr create-repository --profile $(PROFILE) --region $(REGION) --repository-name $(PROJECT) || :
 	@aws iam attach-role-policy --role-name aws-elasticbeanstalk-ec2-role --policy-arn arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly --profile $(PROFILE) --region $(REGION)
 
+package-app:
+	.build/package-app.sh
+
 ##############################
 # Local development commands #
 ##############################

--- a/packages/bcer-api/README.md
+++ b/packages/bcer-api/README.md
@@ -146,9 +146,11 @@ In short:
 [NestJS](https://docs.nestjs.com).
 
 ## Deployment
-To prepare the NodeJS app for deployment, thereyou only need to run two things:
-- In the `app` directory, run `npm run build:prem"`
-- Run `npm run tar` to produce a `.tar.gz` file
+To prepare the NodeJS app for deployment, you need to build and package the app:
+
+`make package-app`
+
+Note: it's encouraged to use the build functionality provided at the root of the project which will build all parts of the app instead of building each piece individually.
 
 This produces a whole package that includes all the files necessary. For deployment, it is only required to replace specific values in the produced `.env` file. The values are
 ```

--- a/packages/bcer-data-portal/.build/package-app.sh
+++ b/packages/bcer-data-portal/.build/package-app.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ -z "${ENVIRONMENT}" ]; then
+    echo "No ENVIRONMENT specified"
+    exit 0;
+fi
+
+echo "+\n++ Building data portal"
+make setup-${ENVIRONMENT}-env
+cd app
+npm i
+npm run build
+npm run tar
+echo "\n++ Finished building data portal"

--- a/packages/bcer-data-portal/Makefile
+++ b/packages/bcer-data-portal/Makefile
@@ -157,6 +157,9 @@ pipeline-report:
 	@echo "+\n++ Reporting...\n+"
 	@docker cp $(PROJECT)-test:/app/test-results .
 
+package-app:
+	.build/package-app.sh
+
 ##############################
 # Pipeline clean up commands #
 ##############################

--- a/packages/bcer-data-portal/README.md
+++ b/packages/bcer-data-portal/README.md
@@ -81,12 +81,10 @@ Generate a coverage report with `npm run test:cov`
 ## Deployment
 There are a couple of steps involved with deploying to each environment.
 
-- Navigate to the root folder and run `make setup-<env>-env`. Replace <env> with the desired environment
--- Dev: `setup-development-env`
--- Test: `setup-staging-env`
--- Prod: `setup-prod-env`
-- Navigate to the `app` directory and run `npm run build`
-- Run `npm run tar`, to generate the `.tar.gz` files to be used for deployment
+1. Build + package the app - run `ENVIRONMENT=<development|staging|prod> VERSION=<version> make package-app`. This will output `build.tar.gz` which contains the app.
+2. Verify that the build worked
+
+Note: it's encouraged to use the build functionality provided at the root of the project which will build all parts of the app instead of building each piece individually.
 
 There are a couple of possibilities to check for debugging if there are issues.
 - Check that the extracted directory from the `.tar.gz` file points ot the right API and Authentication Provider (Keycloak) values by doing a search and cross-referencing the `.env.development` or `.env.test` or `.env.prod` values.

--- a/packages/bcer-retailer-app/.build/package-app.sh
+++ b/packages/bcer-retailer-app/.build/package-app.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ -z "${ENVIRONMENT}" ]; then
+    echo "No ENVIRONMENT specified"
+    exit 0;
+fi
+
+echo "+\n++ Building retailer app"
+make setup-${ENVIRONMENT}-env
+cd app
+npm i
+npm run build
+npm run tar
+echo "\n++ Finished building retailer app"

--- a/packages/bcer-retailer-app/Makefile
+++ b/packages/bcer-retailer-app/Makefile
@@ -79,6 +79,7 @@ create-ecr-repos:
 	@aws ecr create-repository --profile $(PROFILE) --region $(REGION) --repository-name $(PROJECT) || :
 	@aws iam attach-role-policy --role-name aws-elasticbeanstalk-ec2-role --policy-arn arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly --profile $(PROFILE) --region $(REGION)
 
+
 ##############################
 # Local development commands #
 ##############################
@@ -140,6 +141,9 @@ pipeline-deploy-version:
 
 pipeline-healthcheck:
 	@aws --profile $(PROFILE) elasticbeanstalk describe-environments --application-name $(PROJECT) --environment-name $(DEPLOY_ENV) --query 'Environments[*].{Status: Status, Health: Health}'
+
+package-app:
+	.build/package-app.sh
 
 ############################################
 # Pipeline lint, test, and report commands #

--- a/packages/bcer-retailer-app/README.md
+++ b/packages/bcer-retailer-app/README.md
@@ -72,12 +72,10 @@ Generate a coverage report with `npm run test:cov`
 ## Deployment
 There are a couple of steps involved with deploying to each environment.
 
-- Navigate to the root folder and run `make setup-<env>-env`. Replace <env> with the desired environment
--- Dev: `setup-development-env`
--- Test: `setup-staging-env`
--- Prod: `setup-prod-env`
-- Navigate to the `app` directory and run `npm run build`
-- Run `npm run tar`, to generate the `.tar.gz` files to be used for deployment
+1. Build + package the app - run `ENVIRONMENT=<development|staging|prod> VERSION=<version> make package-app`. This will output `build.tar.gz` which contains the app.
+2. Verify that the build worked
+
+Note: it's encouraged to use the build functionality provided at the root of the project which will build all parts of the app instead of building each piece individually.
 
 There are a couple of possibilities to check for debugging if there are issues.
 - Check that the extracted directory from the `.tar.gz` file points ot the right API and Authentication Provider (Keycloak) values by doing a search and cross-referencing the `.env.development` or `.env.test` or `.env.prod` values.

--- a/packages/bcer-shared-components/Makefile
+++ b/packages/bcer-shared-components/Makefile
@@ -4,3 +4,9 @@ prepare-push:
 	@echo "+\n++ Make: Preparing modules for pushing to repository...\n+"
 	@rm -rf dist
 	@npm run build
+
+build:
+	@echo "+\n++ Building Shared Components"
+	@npm i
+	@npm run build
+	@echo "+\n++ Finished building shared components"


### PR DESCRIPTION
**Resolves**
Introduces a single build command to build the different parts of the app to make the build process a bit more streamlined and less prone for error.

**Changes**
- Added `make package-build` to the project root to build all parts of the app. Usage: `ENVIRONMENT=development VERSION=1.2.3 make package-build`
- Added `make package-app` to the api, data portal and retailer app if you need to build them separately
