### PR TITLE
Feature/VAPE-407 Added initial github workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: BCER Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version of the app (e.g. v1.2.3)'
+        required: true
+      environment:
+        description: 'Environment (development | staging | production)'
+        required: true
+        default: 'development'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Package App
+      run: VERSION=${{ github.event.inputs.version }} ENVIRONMENT=${{ github.event.inputs.environment }} make package-build
+    - name: Create Github Release
+      uses: softprops/action-gh-release@v1
+      with:
+        draft: false
+        prerelease: ${{ github.event.inputs.environment != 'production'}}
+        name: ${{ github.event.inputs.version }}-${{ github.event.inputs.environment }}
+        tag_name: ${{ github.event.inputs.version }}-${{ github.event.inputs.environment }}
+        files: |
+          dist/*/*
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Send Slack Notification
+      uses: 8398a7/action-slack@v3
+      env:
+        VERSION: ${{ github.event.inputs.version }}
+        ENVIRONMENT: ${{ github.event.inputs.environment }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+      with:
+        status: custom
+        custom_payload: |
+          {
+            text: `New development release ready: ${process.env.VERSION}`,
+            attachments: [{
+              "author_name": "Github",
+              fallback: "fallback",
+              color: "good",
+              title: "New release",
+              text: "Created",
+              fields: [{
+                title: "Author",
+                value: process.env.GITHUB_ACTOR,
+                short: true
+              },
+              {
+                title: "Url",
+                value: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/releases/tag/${process.env.VERSION}-${process.env.ENVIRONMENT}`,
+                short: true
+              },
+              {
+                title: "Environment",
+                value: "development",
+                short: false
+              },
+              {
+                title: "Version",
+                value: process.env.VERSION,
+                short: false
+              }],
+              actions: [{
+              }]
+            }]
+          }

--- a/packages/bcer-api/Makefile
+++ b/packages/bcer-api/Makefile
@@ -1,6 +1,6 @@
 #!make
 
-include .env
+-include .env
 -include app/.env
 
 export $(shell sed 's/=.*//' .env)

--- a/packages/bcer-data-portal/Makefile
+++ b/packages/bcer-data-portal/Makefile
@@ -1,6 +1,6 @@
 #!make
 
-include .env
+-include .env
 -include app/.env
 
 export $(shell sed 's/=.*//' .env)

--- a/packages/bcer-retailer-app/Makefile
+++ b/packages/bcer-retailer-app/Makefile
@@ -1,6 +1,6 @@
 #!make
 
-include .env
+-include .env
 -include app/.env
 
 export $(shell sed 's/=.*//' .env)


### PR DESCRIPTION
**GH Action**
Added a github action (manually triggered) to build the app and create a Github release withe the built files attached.

1. Build app for the environment/version specified when running the action
2. Create a Github release with the version specified. Dev / staging builds are tagged as "prereleases".
3. Send a slack notification with a link to the newly created release