### PR TITLE
VAPE-376 Add city + postal code to location search

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,6 +19,24 @@ services:
       - application
     networks:
       - backend
+  data-portal:
+    image: bcer-data-portal:dev
+    container_name: bcer-data-portal
+    build:
+      context: ./packages
+      dockerfile: Dockerfile.data-portal.dev
+    ports:
+      - "3001:3000"
+    volumes:
+      - ./packages/bcer-data-portal:/usr/src/app/bcer-data-portal
+      - ./packages/bcer-shared-components:/usr/src/app/bcer-shared-components
+      - /usr/src/app/bcer-data-portal/app/node_modules
+      - /usr/src/app/bcer-shared-components/node_modules
+    depends_on:
+      - postgres
+      - application
+    networks:
+      - backend
 
   application:
     image: vape-nest-api:dev

--- a/packages/Dockerfile.data-portal.dev
+++ b/packages/Dockerfile.data-portal.dev
@@ -1,0 +1,17 @@
+FROM node:14.16.1
+
+MAINTAINER FreshWorks <web@freshworks.io>
+
+ENV PATH $PATH:/usr/src/app/node_modules/.bin
+
+WORKDIR /usr/src/app
+
+COPY ./bcer-data-portal/app/package*.json ./bcer-data-portal/app/
+COPY ./bcer-shared-components/package*.json ./bcer-shared-components/
+
+# Install dependencies
+RUN cd ./bcer-data-portal/app && npm i && cd ../
+
+EXPOSE 3000
+
+CMD [ "npm", "--prefix", "./bcer-data-portal/app/", "run", "start" ]

--- a/packages/bcer-api/app/src/location/location.service.ts
+++ b/packages/bcer-api/app/src/location/location.service.ts
@@ -88,7 +88,16 @@ export class LocationService {
     qb.where('location.noi IS NOT NULL');
 
     if (query.search) {
-      qb.andWhere('(LOWER(location.addressLine1) LIKE :search OR LOWER(location.doingBusinessAs) LIKE :search OR LOWER(business.legalName) LIKE :search OR LOWER(business.businessName) LIKE :search)', { search: `%${query.search.toLowerCase()}%` });
+      qb.andWhere(`
+        (
+          LOWER(location.addressLine1) LIKE :search OR
+          LOWER(location.doingBusinessAs) LIKE :search OR
+          LOWER(location.city) LIKE :search OR
+          REPLACE(LOWER(location.postal), ' ', '') LIKE REPLACE(:search, ' ', '') OR
+          LOWER(business.legalName) LIKE :search OR
+          LOWER(business.businessName) LIKE :search
+        )
+      `, { search: `%${query.search.toLowerCase()}%` });
     }
     if (query.authority) {
       qb.andWhere(`location.health_authority = :authority`, { authority: query.authority });


### PR DESCRIPTION
**Changes**
- Modified location search functionality to also search by city / postal code. 
- Also added the data portal to our dev docker-compose running on `localhost:3001`. This can be accessed by first logging in to the retailer portal at localhost:3000 and then going to `localhost:3000` (until the Keycloak config has been updated)