### PR TITLE
Fixed issue with notification requests not working when proxying over http

### DIFF
--- a/packages/bcer-api/app/package-lock.json
+++ b/packages/bcer-api/app/package-lock.json
@@ -6959,11 +6959,11 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {

--- a/packages/bcer-api/app/package.json
+++ b/packages/bcer-api/app/package.json
@@ -50,6 +50,7 @@
     "csvtojson": "2.0.10",
     "dotenv": "8.2.0",
     "faker": "4.1.0",
+    "https-proxy-agent": "5.0.0",
     "jsonwebtoken": "8.5.1",
     "jszip": "3.5.0",
     "jwks-rsa": "1.10.1",

--- a/packages/bcer-api/app/src/notification/notification.client.ts
+++ b/packages/bcer-api/app/src/notification/notification.client.ts
@@ -1,0 +1,98 @@
+import { NotifyClient } from 'notifications-node-client';
+import jwt from 'jsonwebtoken';
+import axios, { AxiosRequestConfig } from 'axios';
+import { HttpsProxyAgent, HttpsProxyAgentOptions } from 'https-proxy-agent';
+
+const version = 1.0;
+
+// Sign a JWT to use for authentication with the notification service
+const createToken = (secret: string, clientId: string) => {
+  return jwt.sign(
+    {
+      iss: clientId,
+      iat: Math.round(Date.now() / 1000)
+    },
+    secret,
+    {
+      header: {typ: "JWT", alg: "HS256"}
+    }
+  );    
+}
+  
+
+/**
+ * Basic API client to communicate with the CGNotify APIs.
+ * This implementation differs from the one found in `notifications-node-client` in that
+ * it uses `https-proxy-agent` instead of the proxy functionality provided
+ * by axios seeing as axios does not correctly support proxying https calls over http.
+ * 
+ * This is required by our application to proxy our calls through our forward proxy.
+ */
+class BCERNotifyAPIClient {
+  private readonly apiKeyId: string;
+  private readonly serviceId: string;
+  private proxyAgent: HttpsProxyAgent;
+  
+  constructor(
+      private readonly urlBase: string,
+      apiKey: string
+    ) {
+      this.apiKeyId = apiKey.substring(apiKey.length - 36, apiKey.length);
+      this.serviceId = apiKey.substring(apiKey.length - 73, apiKey.length - 37);
+  }
+    
+  get(path: string) {
+    const options: AxiosRequestConfig = {
+      method: 'get',
+      url: this.urlBase + path,
+      headers: {
+        'Authorization': 'Bearer ' + createToken(this.apiKeyId, this.serviceId),
+        'User-Agent': 'NOTIFY-API-NODE-CLIENT/' + version
+      }
+    };
+    
+    if(this.proxyAgent) {
+      options.httpsAgent = this.proxyAgent;
+    }
+    
+    return axios(options)
+  }
+  
+  post(path:string, data: any){
+    const options: AxiosRequestConfig = {
+      method: 'post',
+      url: this.urlBase + path,
+      data: data,
+      headers: {
+        'Authorization': 'Bearer ' + createToken(this.apiKeyId, this.serviceId),
+        'User-Agent': 'NOTIFY-API-NODE-CLIENT/' + version
+      }
+    };
+    
+    if(this.proxyAgent) {
+      options.httpsAgent = this.proxyAgent;
+    }
+    
+    return axios(options);
+  }
+  
+  setProxyAgent(proxyAgent: HttpsProxyAgentOptions) {
+    this.proxyAgent = new HttpsProxyAgent(proxyAgent);
+  }
+  
+}
+  
+
+export class BCERNotifyClient extends NotifyClient {
+  apiClient: any;
+  
+  constructor(apiEndpoint: string, apiKey: string) {
+    super(apiEndpoint, apiKey);
+    this.apiClient = new BCERNotifyAPIClient(apiEndpoint, apiKey);
+  }
+  
+  setProxy(config: HttpsProxyAgentOptions) {
+    this.apiClient.setProxyAgent(config);
+  }
+}
+    

--- a/packages/bcer-api/app/src/notification/textService.ts
+++ b/packages/bcer-api/app/src/notification/textService.ts
@@ -1,8 +1,8 @@
 import { Logger, NotAcceptableException } from '@nestjs/common';
-import { NotifyClient } from 'notifications-node-client';
 import { sleep } from 'src/utils/util';
 import { NotificationReportDTO } from './dto/notification-report.dto';
 import { NotificationDTO } from './dto/notification.dto';
+import { BCERNotifyClient } from './notification.client';
 
 export class TextService {
   private readonly apiEndpoint =
@@ -15,7 +15,7 @@ export class TextService {
   private messageClient: any;
 
   constructor() {
-    this.messageClient = new NotifyClient(this.apiEndpoint, this.apiKey);
+    this.messageClient = new BCERNotifyClient(this.apiEndpoint, this.apiKey);
     
     if(process.env.TEXT_API_PROXY) {
       this.messageClient.setProxy({


### PR DESCRIPTION
Axios seems to break if you're proxying a https call over http (https://github.com/axios/axios/issues/3384). Unfortunately this is happening when using the forward proxy, breaking any calls to the notification service.

**Fix**
Implemented our own version of the underlying notification service, using [https://www.npmjs.com/package/https-proxy-agent](https-proxy-agent) instead of the built in `axios` proxy functionality