### PR TITLE
VAPE-505 Added Health Authority Boundary map overlay

### DIFF
--- a/packages/bcer-data-portal/app/src/constants/localInterfaces.tsx
+++ b/packages/bcer-data-portal/app/src/constants/localInterfaces.tsx
@@ -156,6 +156,7 @@ export interface RouteOptions {
   globalDistortionField: boolean;
   turnCost: boolean;
   localDistortionField: boolean;
+  haOverlay: boolean;
 }
 
 export interface DirectionNotification {

--- a/packages/bcer-data-portal/app/src/hooks/useLeaflet.tsx
+++ b/packages/bcer-data-portal/app/src/hooks/useLeaflet.tsx
@@ -371,7 +371,7 @@ function useLeaflet(locationIds: string, config: LocationConfig) {
  * based on the BC Health Authority Boundaries Dataset (https://catalogue.data.gov.bc.ca/dataset/health-authority-boundaries)
  * @param m Leaflet map where leayer needs to be added
  */
-  function createHealthAuthorityLayer() {
+function createHealthAuthorityLayer() {
   // Add health authority boundary layer to map
   const mywms = L.tileLayer.wms('https://openmaps.gov.bc.ca/geo/pub/WHSE_ADMIN_BOUNDARIES.BCHA_HEALTH_AUTHORITY_BNDRY_SP/ows?service=WMS', {
       layers: 'pub:WHSE_ADMIN_BOUNDARIES.BCHA_HEALTH_AUTHORITY_BNDRY_SP',
@@ -390,12 +390,9 @@ function createHealthAuthorityLegend() {
     options: {
       position: 'bottomright'
     },
-
     onAdd: () => {
       const container = L.DomUtil.create('div', 'legendwrapper');
-
-      container.innerHTML = `<img src="https://openmaps.gov.bc.ca/geo/pub/WHSE_ADMIN_BOUNDARIES.BCHA_HEALTH_AUTHORITY_BNDRY_SP/ows?service=WMS&request=GetLegendGraphic&format=image%2Fpng&width=30&height=30&layer=pub%3AWHSE_ADMIN_BOUNDARIES.BCHA_HEALTH_AUTHORITY_BNDRY_SP">`
-
+      container.innerHTML = `<img src="https://openmaps.gov.bc.ca/geo/pub/WHSE_ADMIN_BOUNDARIES.BCHA_HEALTH_AUTHORITY_BNDRY_SP/ows?service=WMS&request=GetLegendGraphic&format=image%2Fpng&width=30&height=30&layer=pub%3AWHSE_ADMIN_BOUNDARIES.BCHA_HEALTH_AUTHORITY_BNDRY_SP">`;
       return container;
     }
   });

--- a/packages/bcer-data-portal/app/src/views/Map/LeftPanel.tsx
+++ b/packages/bcer-data-portal/app/src/views/Map/LeftPanel.tsx
@@ -56,6 +56,7 @@ interface LeftPanelProps {
   routeData: BCDirectionData;
   createGoogleLink: () => string;
   setRouteOptions: React.Dispatch<SetStateAction<RouteOptions>>;
+  setShowHALayer: React.Dispatch<SetStateAction<boolean>>,
   directionError: AxiosError;
 }
 
@@ -72,6 +73,7 @@ function LeftPanel({
   routeData,
   createGoogleLink,
   setRouteOptions,
+  setShowHALayer,
   directionError,
 }: LeftPanelProps) {
   const classes = useStyles();
@@ -135,6 +137,7 @@ function LeftPanel({
       <MapControl
         initialRoutingOptions={initialRoutingOptions}
         setRouteOptions={setRouteOptions}
+        setShowHALayer={setShowHALayer}
       />
       {routeData?.visitOrder && locations && (
         <OptimizedOrder

--- a/packages/bcer-data-portal/app/src/views/Map/Map.tsx
+++ b/packages/bcer-data-portal/app/src/views/Map/Map.tsx
@@ -32,6 +32,7 @@ function Map({config}: MapProps) {
     showOnMapHandler,
     createGoogleLink,
     setRouteOptions,
+    setShowHALayer,
     directionError,
   } = useLeaflet(locationIds, config);
 
@@ -62,6 +63,7 @@ function Map({config}: MapProps) {
             createGoogleLink={createGoogleLink}
             setRouteOptions={setRouteOptions}
             directionError={directionError}
+            setShowHALayer={setShowHALayer}
           />
         </Box>
       </Drawer>

--- a/packages/bcer-data-portal/app/src/views/Map/MapControl.tsx
+++ b/packages/bcer-data-portal/app/src/views/Map/MapControl.tsx
@@ -34,9 +34,11 @@ const useStyles = makeStyles(() => ({
 function MapControl({
   initialRoutingOptions,
   setRouteOptions,
+  setShowHALayer,
 }: {
   initialRoutingOptions: RouteOptions;
   setRouteOptions: React.Dispatch<SetStateAction<RouteOptions>>;
+  setShowHALayer: React.Dispatch<SetStateAction<boolean>>;
 }) {
   const classes = useStyles();
   return (
@@ -46,7 +48,25 @@ function MapControl({
         onSubmit={(v) => setRouteOptions(v)}
       >
         {({ values, ...helpers }) => (
-          <Form>
+          <Form
+            onChange={(e:any) => {
+              if(e.target.name === 'haOverlay') {
+                setShowHALayer(e.target.checked);
+              }
+            }}
+          >
+            <Box mt={2} mb={2}>
+              <Typography className={classes.text}>Map Options</Typography>
+              <Box className={classes.routeOption}>
+                <Box>
+                  <StyledCheckboxInput
+                    name="haOverlay"
+                    label="Display Health Authority Boundaries"
+                  />
+                </Box>
+              </Box>
+            </Box>
+
             <Typography className={classes.text}>Filter Options</Typography>
             <Box className={classes.routeOption}>
               <Box flex={0.5}>


### PR DESCRIPTION
Added a togglable(?) map overlay to display Health Authority Boundaries.

This is done using Leaflet's WMS support, combined with the BC Gov Map Service to actually render the tiles to display: [](https://www2.gov.bc.ca/gov/content/data/geographic-data-services/web-based-mapping/map-services)


![image](https://user-images.githubusercontent.com/66635118/158900634-af2a7888-53fd-4b0c-b6e5-e744c0a0c1ce.png)
