### PR TITLE
add new column to product reports page tables

### DIFF
--- a/packages/bcer-retailer-app/app/src/views/productReport/Overview.tsx
+++ b/packages/bcer-retailer-app/app/src/views/productReport/Overview.tsx
@@ -333,6 +333,9 @@ export default function ProductOverview() {
                     title: 'Status',
                     render: (rd: BusinessLocation) => `${rd?.products?.length ? 'Submitted' : 'Not Submitted'}`
                   },
+                  {
+                    title: 'Doing Business as', render: (rd: BusinessLocation) => rd.doingBusinessAs
+                  },
                 ]}
                 data={withoutProducts}
               />
@@ -370,6 +373,9 @@ export default function ProductOverview() {
                   {
                     title: 'Status',
                     render: (rd: BusinessLocation) => `${rd.products?.length || rd.productsCount > 0 ? 'Submitted' : 'Not Submitted'}`
+                  },
+                  {
+                    title: 'Doing Business as', render: (rd: BusinessLocation) => rd.doingBusinessAs
                   },
                 ]}
                 actions={[


### PR DESCRIPTION
add "Doing Business as" column to the product reports "locations with…out product reports" and "locations with product reports" tables.

No backend changes were needed as doingBusinessAs value is already pulled from backend call. Just needed to display it