### PR TITLE
added new dropdown component and used it in location information for two of the fields (underage and manufactoring)

### DIFF
--- a/packages/bcer-data-portal/app/src/components/generic/StyledEditableDropdown.tsx
+++ b/packages/bcer-data-portal/app/src/components/generic/StyledEditableDropdown.tsx
@@ -1,0 +1,89 @@
+import React, { useState, useEffect, useRef } from 'react';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import { styled } from '@mui/system';
+import useLocation from '@/hooks/useLocation';
+import useNetworkErrorMessage from '@/hooks/useNetworkErrorMessage';
+
+const StyledSelect = styled(Select)({
+  '& .MuiInputBase-input': {
+    color: 'black',
+    fontSize: '14px',
+    fontWeight: 600,
+    WebkitTextFillColor: 'black',
+  },
+  '& .MuiInput-underline:before': {
+    borderBottomStyle: 'none',
+  },
+  '& .MuiSelect-select:focus': {
+    backgroundColor: 'transparent',
+  },
+  '& .Mui-selected': {
+    backgroundColor: 'transparent !important',
+  },
+});
+
+interface StyledEditableDropdownProps {
+  id: string;
+  value: any;
+  type: string;
+  options: Array<{ label: string; value: any }>;
+  onSuccessfulUpdate?: (data: string) => void;
+}
+
+function StyledEditableDropdown({ id, value, type, options, onSuccessfulUpdate }: StyledEditableDropdownProps) {
+  const [content, setContent] = useState(value);
+  const { updateLocationInfo, patchLocationError } = useLocation(id);
+  const [noteMessage, updateNoteMessage] = useState('');
+  const { showNetworkErrorMessage } = useNetworkErrorMessage();
+  const notInitialRender = useRef(false);
+
+  useEffect(() => {
+    if (notInitialRender.current) {
+      const sendToDB = async () => {
+        await updateLocationInfo(type, content);
+
+        if (patchLocationError) {
+          showNetworkErrorMessage(patchLocationError);
+        } else {
+          onSuccessfulUpdate(noteMessage + ' to ' + content);
+        }
+      };
+
+      sendToDB();
+    } else {
+      notInitialRender.current = true;
+    }
+  }, [content]);
+
+  const handleChange = (event:any) => {
+    updateNoteMessage(type + ' changed from ' + content);
+    setContent(event.target.value);
+  };
+
+  const isLegacyValue = !options.some(option => option.value === content);
+  
+  return (
+    <>
+      <StyledSelect
+        name={type}
+        value={content}
+        onChange={handleChange}
+        variant="standard"
+      >
+        {isLegacyValue && (
+          <MenuItem value={content} disabled>
+            {content}
+          </MenuItem>
+        )}
+        {options.map((option) => (
+          <MenuItem key={option.value} value={option.value}>
+            {option.label}
+          </MenuItem>
+        ))}
+      </StyledSelect>
+    </>
+  );
+}
+
+export default StyledEditableDropdown;

--- a/packages/bcer-data-portal/app/src/components/generic/StyledEditableTextField.tsx
+++ b/packages/bcer-data-portal/app/src/components/generic/StyledEditableTextField.tsx
@@ -7,6 +7,7 @@ import { styled } from '@mui/system';
 import useLocation from '@/hooks/useLocation';
 import useNetworkErrorMessage from '@/hooks/useNetworkErrorMessage';
 import StyledEditDialog from './StyledEditDialog';
+import StyledEditableDropdown from './StyledEditableDropdown';
 
 const StyledTextField = styled(TextField)({
   '& .MuiInputBase-input.Mui-disabled': {
@@ -27,12 +28,6 @@ interface StyledEditableTextFieldProps {
   onSuccessfulUpdate?: (data: string) => void;
 }
 
-// This is the editable text field component for the location information on Location Details page, it allows the user to update the location information and it stores the edit history into Notes
-// id: location id
-// value: user's input
-// type: addressLine1 || postal || webpage || phone || email || underage || manufacturing
-// onSuccessfulUpdate: the function to save the change to the note
-
 function StyledEditableTextField({ id, value, type, onSuccessfulUpdate }: StyledEditableTextFieldProps) {
   const [content, setContent] = useState(value);
   const [city, setCity] = useState('');
@@ -41,7 +36,7 @@ function StyledEditableTextField({ id, value, type, onSuccessfulUpdate }: Styled
   const [latitude, setLatitude] = useState(null);
   const [geo_confidence, setGeo_confidence] = useState('');
   const [mouseOver, setMouseOver] = useState(false);
-  const [dialogOpen, setDialogOpen] = useState(false); // State to manage dialog open state
+  const [dialogOpen, setDialogOpen] = useState(false);
   const { updateLocationInfo, patchLocationError } = useLocation(id);
   const [noteMessage, updateNoteMessage] = useState('');
   const { showNetworkErrorMessage } = useNetworkErrorMessage();
@@ -106,25 +101,42 @@ function StyledEditableTextField({ id, value, type, onSuccessfulUpdate }: Styled
     setDialogOpen(false);
   };
 
+  const dropdownOptions = [
+    { label: 'Yes', value: "Yes" },
+    { label: 'No', value: "No" },
+  ];
+
+  const dropdownTypes = ['underage', 'manufacturing'];
+  
   return (
     <>
-      <StyledTextField
-        name={type}
-        disabled={true}
-        value={content}
-        onMouseEnter={handleMouseOver}
-        onMouseLeave={handleMouseOut}
-        InputProps={{
-          endAdornment: mouseOver ? (
-            <InputAdornment position="end">
-              <IconButton style={{ color: '#0053A5' }} onClick={handleDialogOpen}>
-                <EditIcon />
-              </IconButton>
-            </InputAdornment>
-          ) : null,
-        }}
-        variant="standard"
-      />
+      { dropdownTypes.includes(type) ? (
+        <StyledEditableDropdown
+          id={id}
+          value={content}
+          type={type}
+          options={dropdownOptions}
+          onSuccessfulUpdate={onSuccessfulUpdate}
+        />
+      ) : (
+        <StyledTextField
+          name={type}
+          disabled={true}
+          value={content}
+          onMouseEnter={handleMouseOver}
+          onMouseLeave={handleMouseOut}
+          InputProps={{
+            endAdornment: mouseOver ? (
+              <InputAdornment position="end">
+                <IconButton style={{ color: '#0053A5' }} onClick={handleDialogOpen}>
+                  <EditIcon />
+                </IconButton>
+              </InputAdornment>
+            ) : null,
+          }}
+          variant="standard"
+        />
+      )}
       <StyledEditDialog
         type={type}
         saveChange={updateContent}

--- a/packages/bcer-data-portal/app/src/components/generic/StyledEditableTextField.tsx
+++ b/packages/bcer-data-portal/app/src/components/generic/StyledEditableTextField.tsx
@@ -28,6 +28,12 @@ interface StyledEditableTextFieldProps {
   onSuccessfulUpdate?: (data: string) => void;
 }
 
+// This is the editable text field component for the location information on Location Details page, it allows the user to update the location information and it stores the edit history into Notes
+// id: location id
+// value: user's input
+// type: addressLine1 || postal || webpage || phone || email || underage || manufacturing
+// onSuccessfulUpdate: the function to save the change to the note
+
 function StyledEditableTextField({ id, value, type, onSuccessfulUpdate }: StyledEditableTextFieldProps) {
   const [content, setContent] = useState(value);
   const [city, setCity] = useState('');


### PR DESCRIPTION
This updates the location information form for two of the fields:
1) "If persons under 19 years of age are permitted on the sales premises"
2) "Intent to manufacture e-substances for sale at this business location"
Where they are now dropdowns with the options of selecting "Yes" or "No" instead of free text fields. If there is legacy data that is not "Yes" or "No" it will be displayed.

changes:
* added new StyledEditableDropdown component 
* changed StyledEditableTextField to use new dropdown when the field type is inside dropdownTypes array ('underage' or 'manufactoring')