### PR TITLE
upgrade PostgreSQL version from v13.12 to v13.18

### DIFF
--- a/Infrastructure/aurora-v2.tf
+++ b/Infrastructure/aurora-v2.tf
@@ -41,7 +41,7 @@ module "aurora_postgresql_v2" {
   name              = "${var.bcer_cluster_name}-${var.target_env}"
   engine            = "aurora-postgresql"
   engine_mode       = "provisioned"
-  engine_version    = "13.12"
+  engine_version    = "13.18"
   storage_encrypted = true
   database_name     = var.bcer_database_name
 


### PR DESCRIPTION
AWS deployment failed during "Terragrunt apply" step with PostgreSQL version mismatch error:

AWS automatically upgraded the RDS Aurora PostgreSQL cluster from version 13.12 to 13.18 however Terraform configuration still use engine version as "13.12". 