### PR TITLE
BCMOHAM-29871: Dockerfiles vulnerability fix

### DIFF
--- a/packages/Dockerfile.data-portal.dev
+++ b/packages/Dockerfile.data-portal.dev
@@ -1,4 +1,8 @@
+<<<<<<< Updated upstream
 FROM node:24.11.1
+=======
+FROM node:24.12.0-trixie-slim
+>>>>>>> Stashed changes
 
 LABEL maintainer="CGI"
 

--- a/packages/Dockerfile.data-portal.dev
+++ b/packages/Dockerfile.data-portal.dev
@@ -1,8 +1,4 @@
-<<<<<<< Updated upstream
-FROM node:24.11.1
-=======
 FROM node:24.12.0-trixie-slim
->>>>>>> Stashed changes
 
 LABEL maintainer="CGI"
 

--- a/packages/Dockerfile.data-portal.test
+++ b/packages/Dockerfile.data-portal.test
@@ -1,4 +1,4 @@
-FROM node:24.4.1 as builder
+FROM node:24.12.0-trixie-slim as builder
 
 LABEL maintainer="CGI"
 

--- a/packages/Dockerfile.retailer-app.dev
+++ b/packages/Dockerfile.retailer-app.dev
@@ -1,4 +1,8 @@
+<<<<<<< Updated upstream
 FROM node:24.11.1
+=======
+FROM node:24.12.0-trixie-slim
+>>>>>>> Stashed changes
 
 LABEL maintainer="CGI"
 

--- a/packages/Dockerfile.retailer-app.dev
+++ b/packages/Dockerfile.retailer-app.dev
@@ -1,8 +1,4 @@
-<<<<<<< Updated upstream
-FROM node:24.11.1
-=======
 FROM node:24.12.0-trixie-slim
->>>>>>> Stashed changes
 
 LABEL maintainer="CGI"
 

--- a/packages/Dockerfile.retailer-app.test
+++ b/packages/Dockerfile.retailer-app.test
@@ -1,4 +1,4 @@
-FROM node:24.4.1 as builder
+FROM node:24.12.0-trixie-slim as builder
 
 LABEL maintainer="CGI"
 

--- a/packages/bcer-api/app/Dockerfile.aws
+++ b/packages/bcer-api/app/Dockerfile.aws
@@ -1,4 +1,4 @@
-FROM node:24.4.1
+FROM node:24.12.0-trixie-slim
 
 ENV PATH=$PATH:/usr/src/app/node_modules/.bin
 

--- a/packages/bcer-api/app/Dockerfile.aws.migrations
+++ b/packages/bcer-api/app/Dockerfile.aws.migrations
@@ -1,4 +1,4 @@
-FROM node:24.4.1
+FROM node:24.12.0-trixie-slim
 
 ENV PATH=$PATH:/usr/src/app/node_modules/.bin
 

--- a/packages/bcer-api/app/Dockerfile.dev
+++ b/packages/bcer-api/app/Dockerfile.dev
@@ -1,4 +1,8 @@
+<<<<<<< Updated upstream
 FROM node:24.11.1
+=======
+FROM node:24.12.0-trixie-slim
+>>>>>>> Stashed changes
 
 LABEL maintainer="CGI"
 

--- a/packages/bcer-api/app/Dockerfile.dev
+++ b/packages/bcer-api/app/Dockerfile.dev
@@ -1,8 +1,4 @@
-<<<<<<< Updated upstream
-FROM node:24.11.1
-=======
 FROM node:24.12.0-trixie-slim
->>>>>>> Stashed changes
 
 LABEL maintainer="CGI"
 

--- a/packages/bcer-api/app/Dockerfile.production
+++ b/packages/bcer-api/app/Dockerfile.production
@@ -1,4 +1,4 @@
-FROM node:24.4.1
+FROM node:24.12.0-trixie-slim
 
 LABEL maintainer="CGI"
 

--- a/packages/bcer-api/app/Dockerfile.test
+++ b/packages/bcer-api/app/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM node:24.4.1
+FROM node:24.12.0-trixie-slim
 
 LABEL maintainer="CGI"
 

--- a/packages/bcer-data-portal/app/docker/Dockerfile.development
+++ b/packages/bcer-data-portal/app/docker/Dockerfile.development
@@ -1,6 +1,6 @@
 # Create development build
 
-FROM node:24.4.1
+FROM node:24.12.0-trixie-slim
 
 LABEL maintainer="CGI"
 

--- a/packages/bcer-data-portal/app/docker/Dockerfile.production
+++ b/packages/bcer-data-portal/app/docker/Dockerfile.production
@@ -1,6 +1,6 @@
 # Create production build
 
-FROM node:24.4.1
+FROM node:24.12.0-trixie-slim
 
 LABEL maintainer="CGI"
 

--- a/packages/bcer-data-portal/app/docker/Dockerfile.test
+++ b/packages/bcer-data-portal/app/docker/Dockerfile.test
@@ -1,6 +1,6 @@
 # Create test build
 
-FROM node:24.4.1
+FROM node:24.12.0-trixie-slim
 LABEL maintainer="CGI"
 ENV PATH=$PATH:/app/node_modules/.bin
 

--- a/packages/bcer-retailer-app/app/docker/Dockerfile.development
+++ b/packages/bcer-retailer-app/app/docker/Dockerfile.development
@@ -1,6 +1,6 @@
 # Create development build
 
-FROM node:24.4.1
+FROM node:24.12.0-trixie-slim
 
 LABEL maintainer="CGI"
 

--- a/packages/bcer-retailer-app/app/docker/Dockerfile.production
+++ b/packages/bcer-retailer-app/app/docker/Dockerfile.production
@@ -1,6 +1,6 @@
 # Create production build
 
-FROM node:24.4.1
+FROM node:24.12.0-trixie-slim
 
 LABEL maintainer="CGI"
 

--- a/packages/bcer-retailer-app/app/docker/Dockerfile.test
+++ b/packages/bcer-retailer-app/app/docker/Dockerfile.test
@@ -1,6 +1,6 @@
 # Create test build
 
-FROM node:24.4.1
+FROM node:24.12.0-trixie-slim
 
 LABEL maintainer="CGI"
 


### PR DESCRIPTION
Upgrading all Dockerfiles to 24.12.0 trixie slim, which is recommended by Snyk with no vulnerabilities:
<img width="1335" height="66" alt="image" src="https://github.com/user-attachments/assets/527201cd-bc53-497d-b96d-91be3885142f" />
